### PR TITLE
Fix wrong ContentEncoding for chunked stream

### DIFF
--- a/src/Signer/SignerV4ForS3.php
+++ b/src/Signer/SignerV4ForS3.php
@@ -115,7 +115,7 @@ class SignerV4ForS3 extends SignerV4
             return;
         }
 
-        // Specify your custom content-encoding for chunked stream
+        // Add content-encoding for chunked stream if available
         $customEncoding = $context->getRequest()->getHeader('content-encoding');
         $contentEncoding = 'aws-chunked';
         if($customEncoding){

--- a/src/Signer/SignerV4ForS3.php
+++ b/src/Signer/SignerV4ForS3.php
@@ -115,8 +115,15 @@ class SignerV4ForS3 extends SignerV4
             return;
         }
 
+        // Specify your custom content-encoding for chunked stream
+        $customEncoding = $context->getRequest()->getHeader('content-encoding');
+        $contentEncoding = 'aws-chunked';
+        if($customEncoding){
+            $contentEncoding .= sprintf(', %s', $customEncoding);
+        }
+
         // Convert the body into a chunked stream
-        $request->setHeader('content-encoding', 'aws-chunked');
+        $request->setHeader('content-encoding', $contentEncoding);
         $request->setHeader('x-amz-decoded-content-length', (string) $contentLength);
         $request->setHeader('x-amz-content-sha256', 'STREAMING-' . self::ALGORITHM_CHUNK);
 


### PR DESCRIPTION
problem
if I specify `ContentEncoding` for a file bigger than `64kb` .. the `Content-Encoding` option will be ignored
![Screenshot 2021-03-22 at 14 02 00](https://user-images.githubusercontent.com/2089749/111993880-692d0980-8b17-11eb-8c4b-450c71559d69.png)

it will appear empty in S3
![Screenshot 2021-03-22 at 14 00 34](https://user-images.githubusercontent.com/2089749/111993732-400c7900-8b17-11eb-9070-922e0fcd3f8c.png)

according to https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
we can add multiple ContentEncoding so I check the request & add the right `ContentEncoding` if available

Actual Result after this PR
![Screenshot 2021-03-22 at 13 54 57](https://user-images.githubusercontent.com/2089749/111993993-8c57b900-8b17-11eb-9401-05e0bacb443e.png)

