### PR TITLE
DateTimeInterface::ISO8601 Incompatibility with ISO8601

### DIFF
--- a/src/Input/CopyObjectRequest.php
+++ b/src/Input/CopyObjectRequest.php
@@ -906,7 +906,7 @@ final class CopyObjectRequest extends Input
             $headers['x-amz-object-lock-mode'] = $this->objectLockMode;
         }
         if (null !== $this->objectLockRetainUntilDate) {
-            $headers['x-amz-object-lock-retain-until-date'] = $this->objectLockRetainUntilDate->format(\DateTimeInterface::ISO8601);
+            $headers['x-amz-object-lock-retain-until-date'] = $this->objectLockRetainUntilDate->format(\DateTimeInterface::ATOM);
         }
         if (null !== $this->objectLockLegalHoldStatus) {
             if (!ObjectLockLegalHoldStatus::exists($this->objectLockLegalHoldStatus)) {

--- a/src/Input/CreateMultipartUploadRequest.php
+++ b/src/Input/CreateMultipartUploadRequest.php
@@ -652,7 +652,7 @@ final class CreateMultipartUploadRequest extends Input
             $headers['x-amz-object-lock-mode'] = $this->objectLockMode;
         }
         if (null !== $this->objectLockRetainUntilDate) {
-            $headers['x-amz-object-lock-retain-until-date'] = $this->objectLockRetainUntilDate->format(\DateTimeInterface::ISO8601);
+            $headers['x-amz-object-lock-retain-until-date'] = $this->objectLockRetainUntilDate->format(\DateTimeInterface::ATOM);
         }
         if (null !== $this->objectLockLegalHoldStatus) {
             if (!ObjectLockLegalHoldStatus::exists($this->objectLockLegalHoldStatus)) {

--- a/src/Input/PutObjectRequest.php
+++ b/src/Input/PutObjectRequest.php
@@ -851,7 +851,7 @@ final class PutObjectRequest extends Input
             $headers['x-amz-object-lock-mode'] = $this->objectLockMode;
         }
         if (null !== $this->objectLockRetainUntilDate) {
-            $headers['x-amz-object-lock-retain-until-date'] = $this->objectLockRetainUntilDate->format(\DateTimeInterface::ISO8601);
+            $headers['x-amz-object-lock-retain-until-date'] = $this->objectLockRetainUntilDate->format(\DateTimeInterface::ATOM);
         }
         if (null !== $this->objectLockLegalHoldStatus) {
             if (!ObjectLockLegalHoldStatus::exists($this->objectLockLegalHoldStatus)) {


### PR DESCRIPTION
According to PHP doc : DateTimeInterface::ISO8601 is not compatible with ISO-8601, but is left this way for backward compatibility reasons. 

Use DateTimeInterface::ISO8601_EXPANDED, DateTimeInterface::ATOM for compatibility with ISO-8601 instead.